### PR TITLE
content/doc: add libXcursor-devel to needed libs

### DIFF
--- a/content/doc/install.md
+++ b/content/doc/install.md
@@ -6,11 +6,11 @@ title: Installation - Gio documentation
 
 ## Linux {#linux}
 
-For Linux you need Wayland and the wayland, x11, xkbcommon, GLES, EGL development packages.
+For Linux you need Wayland and the wayland, x11, xkbcommon, GLES, EGL, libXcursor development packages.
 
 On Fedora 28 and newer, install the dependencies with the command
 
-    $ dnf install wayland-devel libX11-devel libxkbcommon-x11-devel mesa-libGLES-devel mesa-libEGL-devel
+    $ dnf install wayland-devel libX11-devel libxkbcommon-x11-devel mesa-libGLES-devel mesa-libEGL-devel libXcursor-devel
 
 On Ubuntu 18.04 and newer, use
 


### PR DESCRIPTION
Fedora 33 requires libXcursor-devel.