### PR TITLE
content/doc/install: update Fedora instructions

### DIFF
--- a/content/doc/install/linux.md
+++ b/content/doc/install/linux.md
@@ -13,12 +13,12 @@ For Linux you need development packages for:
 
 Depending on your distribution, you may also need to install a Vulkan driver for best performance. Distributions like Arch do not do this automatically. You can check if you have working Vulkan support with the `vulkaninfo` command.
 
-### Fedora 28+
+### Fedora 35+
 
-On Fedora 28 and newer, install the dependencies with the command:
+On Fedora 35 and newer, install the dependencies with the command:
 
 ``` sh
-dnf install gcc pkg-config wayland-devel libX11-devel libxkbcommon-x11-devel mesa-libGLES-devel mesa-libEGL-devel libXcursor-devel mesa-vulkan-devel
+dnf install gcc pkg-config wayland-devel libX11-devel libxkbcommon-x11-devel mesa-libGLES-devel mesa-libEGL-devel libXcursor-devel vulkan-headers
 ```
 
 ### Ubuntu 18.04+


### PR DESCRIPTION
Fedora operates on a cycle of about 13 months support so it makes sense to regularly keep these instructions updated. In this specific case, it seems like the [mesa-vulkan-devel package was removed](https://src.fedoraproject.org/rpms/mesa/c/7c62c9e9b316c0b3c982adb91ba9de5640a63515?branch=rawhide), but simply swapping it with the [vulkan-headers package](https://packages.fedoraproject.org/pkgs/vulkan-headers/vulkan-headers/) allows me to successfully run `go run gioui.org/example/hello@latest` on my Fedora 36 machine.